### PR TITLE
Fix opentelemetry traces examples

### DIFF
--- a/opentelemetry/otel-collector-config.yaml
+++ b/opentelemetry/otel-collector-config.yaml
@@ -9,7 +9,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:
@@ -21,18 +23,18 @@ processors:
     check_interval: 5s
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [memory_ballast, zpages, health_check]


### PR DESCRIPTION
- Currently running `docker compose up` from `examples/opentelemetry` folder the traces don't appear
- With this change the traces would start appearing

[Optional Fixes #Issue]
[#35497](https://github.com/envoyproxy/envoy/issues/35497)