### PR TITLE
golang-http: update example to adapt latest break change

### DIFF
--- a/golang-http/simple/filter.go
+++ b/golang-http/simple/filter.go
@@ -95,7 +95,7 @@ func (f *filter) EncodeTrailers(trailers api.ResponseTrailerMap) api.StatusType 
 }
 
 // OnLog is called when the HTTP stream is ended on HTTP Connection Manager filter.
-func (f *filter) OnLog() {
+func (f *filter) OnLog(reqHeader api.RequestHeaderMap, reqTrailer api.RequestTrailerMap, respHeader api.ResponseHeaderMap, respTrailer api.ResponseTrailerMap) {
 	code, _ := f.callbacks.StreamInfo().ResponseCode()
 	respCode := strconv.Itoa(int(code))
 	api.LogDebug(respCode)
@@ -121,13 +121,13 @@ func (f *filter) OnLog() {
 
 // OnLogDownstreamStart is called when HTTP Connection Manager filter receives a new HTTP request
 // (required the corresponding access log type is enabled)
-func (f *filter) OnLogDownstreamStart() {
+func (f *filter) OnLogDownstreamStart(reqHeader api.RequestHeaderMap) {
 	// also support kicking off a goroutine here, like OnLog.
 }
 
 // OnLogDownstreamPeriodic is called on any HTTP Connection Manager periodic log record
 // (required the corresponding access log type is enabled)
-func (f *filter) OnLogDownstreamPeriodic() {
+func (f *filter) OnLogDownstreamPeriodic(reqHeader api.RequestHeaderMap, reqTrailer api.RequestTrailerMap, respHeader api.ResponseHeaderMap, respTrailer api.ResponseTrailerMap) {
 	// also support kicking off a goroutine here, like OnLog.
 }
 

--- a/golang-http/simple/go.mod
+++ b/golang-http/simple/go.mod
@@ -6,7 +6,7 @@ go 1.20
 // NOTICE: these lines could be generated automatically by "go mod tidy"
 require (
 	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa
-	github.com/envoyproxy/envoy v1.24.0
+	github.com/envoyproxy/envoy v1.31.1-0.20240821014141-c8f58b61c36d
 	google.golang.org/protobuf v1.34.2
 )
 
@@ -16,8 +16,3 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917 // indirect
 )
-
-// TODO: remove when #26173 lands.
-// And check the "API compatibility" section in doc:
-// https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/golang_filter#developing-a-go-plugin
-replace github.com/envoyproxy/envoy => ../../..

--- a/golang-http/simple/go.sum
+++ b/golang-http/simple/go.sum
@@ -1,5 +1,7 @@
 github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa h1:jQCWAUqqlij9Pgj2i/PB79y4KOPYVyFYdROxgaCwdTQ=
 github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa/go.mod h1:x/1Gn8zydmfq8dk6e9PdstVsDgu9RuyIIJqAaF//0IM=
+github.com/envoyproxy/envoy v1.31.1-0.20240821014141-c8f58b61c36d h1:YwwhqKB3CuEDpN2gjj8ed+ptgTgSP9EZ7mWe7WdLgMM=
+github.com/envoyproxy/envoy v1.31.1-0.20240821014141-c8f58b61c36d/go.mod h1:ujBFxE543X8OePZG+FbeR9LnpBxTLu64IAU7A20EB9A=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=


### PR DESCRIPTION
For behavior change:
Change ``OnLogDownstreamStart``, ``OnLogDownstreamPeriodic`` and ``OnLog`` methods so that user can get the request/response's headers and trailers when producing access log.