### PR TITLE
ext_authz: use multi-arc image for opa

### DIFF
--- a/ext_authz/Dockerfile-opa
+++ b/ext_authz/Dockerfile-opa
@@ -1,3 +1,3 @@
-FROM openpolicyagent/opa:0.70.0-istio@sha256:4d9b0636e04635fcd993141346ddbb5b8b96bd6f8c511bdc0b65a5d0e4f740b2
+FROM openpolicyagent/opa:0.70.0-istio-static@sha256:44a21c67041d086d11e2404df22c146993ca691ace24e46f18d9c88b2f41e26b
 
 COPY --chmod=644 ./config/opa-service/policy.rego /etc/policy.rego


### PR DESCRIPTION
use multi-arc image for opa so the example can be run on arm arch, as most of mac nowadays.