### PR TITLE
Update OPA image reference with v1.4.2

### DIFF
--- a/ext_authz/Dockerfile-opa
+++ b/ext_authz/Dockerfile-opa
@@ -1,3 +1,3 @@
-FROM openpolicyagent/opa:0.70.0-istio-static@sha256:808342677946849bd359e519666a0b5097885961d2a8f6482e0c99b598e2a996
+FROM openpolicyagent/opa:1.4.2-envoy-1-static@sha256:073bbd180c52f8a148914a577f5030fda007630268a54087796f55cdab2f6732
 
 COPY --chmod=644 ./config/opa-service/policy.rego /etc/policy.rego


### PR DESCRIPTION
The OPA project has released last year and is now on a regular release cadence. We'd like users to start with 1.x variants. There are some recently published security issues in this version of the plugin as well. I've updated the image here to the latest release of OPA-Envoy plugin.