### PR TITLE
oauth2: fix single-page-app's pass_through_matcher configuration

### DIFF
--- a/single-page-app/envoy.yml
+++ b/single-page-app/envoy.yml
@@ -40,7 +40,7 @@ static_resources:
                   string_match:
                     safe_regex:
                       regex: >-
-                        ^\/(authorize.*|login|logout)$
+                        ^\/(authorize.*|login|logout|hub/user(s/envoydemo/(repos|followers|following))?)$
                   invert_match: true
                 redirect_path_matcher:
                   path:
@@ -119,7 +119,7 @@ static_resources:
                   string_match:
                     safe_regex:
                       regex: >-
-                        ^\/(authorize.*|login|logout)$
+                        ^\/(authorize.*|login|logout|hub/user(s/envoydemo/(repos|followers|following))?)$
                   invert_match: true
                 redirect_path_matcher:
                   path:


### PR DESCRIPTION
### Description

The changes introduced in [envoyproxy/envoy PR #40228](https://github.com/envoyproxy/envoy/pull/40228) and [envoyproxy/examples PR #663](https://github.com/envoyproxy/examples/pull/663) broke the passthrough functionality of the OAuth2 filter: OAuth2 cookies were removed for requests matching the `pass_through_matcher` configuration. This affected setups with multiple OAuth2 filter instances using different `pass_through_matcher` configurations, because the first matching instance removed the OAuth2 cookies--even when a passthrough was intended--impacting subsequent filters that still needed those cookies.

This PR fixes the `pass_through_matcher` configuration of `single-page-app` test, which started failing after fixing the passthrough behavior.
